### PR TITLE
DCWL-1117: removed customs-notification-gateway-performance-test references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Customs Declarations Information service can be run locally from Service Man
 This repository does not have any associated Acceptance Tests.
 
 ### Performance Tests
-To run performance tests, see [here](https://github.com/hmrc/customs-notification-gateway-performance-test).
+To run performance tests, see [here](https://github.com/hmrc/customs-declaration-performance-test).
 
 
 ## API documentation


### PR DESCRIPTION
DCWL-1117: removed customs-notification-gateway-performance-test references